### PR TITLE
Support custom build_file_content

### DIFF
--- a/debian.bzl
+++ b/debian.bzl
@@ -208,11 +208,13 @@ def _setup_package(ctx, package_name, package_path, package_list, export_cc, bui
     buildfile_out = BUILDFILE_BASE
     if export_cc:
         if build_file or build_file_content:
-            fail("Can't use export_cc and build_file or build_file_content at the same time")
+            fail("Can't use 'export_cc' and 'build_file' or 'build_file_content' at the same time")
         buildfile_out += BUILDFILE_CC.format(
             cc_deps = ", ".join(["\"//{}:cc\"".format(dep) for dep in package_deps]),
         )
     elif build_file_content:
+        if build_file:
+            fail("Can't use 'build_file_content' and 'build_file' at the same time")
         buildfile_out = build_file_content
     elif build_file:
         buildfile_out = None


### PR DESCRIPTION
This adds a string parameter `build_file_content` to the `deb_package` rule to allow for customization. One use case are packages that have files under `usr/include` or `usr/lib` that are not allowed in `hdrs` or `srcs`, for example `*.cmake`. With a custom `build_file_content`, we can fix that.