### PR TITLE
Support zst compression in .deb files

### DIFF
--- a/debian.bzl
+++ b/debian.bzl
@@ -178,7 +178,7 @@ def _download_package(ctx, package_name, package_path, package_uri, package_sha2
     if not download_result.success:
         fail("Failed to download deb from '{}'".format(package_uri))
 
-    # determine type of archives in deb
+    # Find out what the data and control archives are called (could be data.tar.xz or data.tar.zst).
     list_contents_result = ctx.execute(
         ["ar", "t", deb_filename],
         working_directory = package_path,

--- a/debian.bzl
+++ b/debian.bzl
@@ -204,7 +204,7 @@ def _download_package(ctx, package_name, package_path, package_uri, package_sha2
         working_directory = package_path,
     )
     if unpack_result.return_code:
-        fail("Unable to unpack 'data.tar.xz' from deb '{}'".format(deb_filename))
+        fail("Unable to unpack '{}' from deb '{}'".format(data_archive, deb_filename))
 
     # Extract the components into the local directory.
     ctx.extract(data_path, output = package_path, stripPrefix = "")


### PR DESCRIPTION
At least Ubuntu 22.04 LTS deb files have `{data,control}.zst` instead of `.xz`. This commit checks the deb file's contents using `ar t` first to determine the type of the archives.